### PR TITLE
feat: update sys-clk settings

### DIFF
--- a/OC Toolkit/boot_package.ini
+++ b/OC Toolkit/boot_package.ini
@@ -163,12 +163,12 @@ set-ini-val './config.ini' 'Uncapped Clocks?sys-clk' footer {json(0,{ini_file(va
 set-ini-val './config.ini' 'Override Boost Mode?sys-clk' footer {json(0,{ini_file(values,override_boost_mode)})}
 set-ini-val './config.ini' 'Auto CPU Boost' footer {json(0,{ini_file(values,auto_cpu_boost)})}
 set-ini-val './config.ini' 'Sync ReverseNX' footer {json(0,{ini_file(values,reversenx_sync)})}
-json '[{"null":"On", "0":"Off", "1":"On"}]'
+json '[{"null":"On", "0":"Off", "1":"On", "2":"On"}]'
 set-ini-val './config.ini' 'GPU DVFS' footer {json(0,{ini_file(values,gpu_dvfs)})}
 
 [backup]
 hex_file '/atmosphere/kips/loader.kip'
-delete '/atmosphere/kips/.bakTK/tmp.ini' 
+delete '/atmosphere/kips/.bakTK/tmp.ini'
 set-ini-val '/atmosphere/kips/.bakTK/tmp.ini' Backup cpuBoost {hex_file(CUST,8,3)}
 set-ini-val '/atmosphere/kips/.bakTK/tmp.ini' Backup cpuUVL {hex_file(CUST,12,1)}
 set-ini-val '/atmosphere/kips/.bakTK/tmp.ini' Backup cpuUVH {hex_file(CUST,252,1)}

--- a/OC Toolkit/boot_package.ini
+++ b/OC Toolkit/boot_package.ini
@@ -162,7 +162,7 @@ json '[{"null":"Off", "0":"Off", "1":"On"}]'
 set-ini-val './config.ini' 'Uncapped Clocks?sys-clk' footer {json(0,{ini_file(values,uncapped_clocks)})}
 set-ini-val './config.ini' 'Override Boost Mode?sys-clk' footer {json(0,{ini_file(values,override_boost_mode)})}
 set-ini-val './config.ini' 'Auto CPU Boost' footer {json(0,{ini_file(values,auto_cpu_boost)})}
-set-ini-val './config.ini' 'Sync ReverseNX' footer {json(0,{ini_file(values,sync_reversenx)})}
+set-ini-val './config.ini' 'Sync ReverseNX' footer {json(0,{ini_file(values,reversenx_sync)})}
 json '[{"null":"On", "0":"Off", "1":"On"}]'
 set-ini-val './config.ini' 'GPU DVFS' footer {json(0,{ini_file(values,gpu_dvfs)})}
 

--- a/OC Toolkit/sys-clk_settings.ini
+++ b/OC Toolkit/sys-clk_settings.ini
@@ -26,9 +26,9 @@ set-ini-val /config/sys-clk/config.ini values auto_cpu_boost 0
 [Sync ReverseNX]
 ;mode=toggle
 on:
-set-ini-val /config/sys-clk/config.ini values sync_reversenx 1
+set-ini-val /config/sys-clk/config.ini values reversenx_sync 1
 off:
-set-ini-val /config/sys-clk/config.ini values sync_reversenx 0
+set-ini-val /config/sys-clk/config.ini values reversenx_sync 0
 
 [GPU DVFS]
 ;mode=toggle?on


### PR DESCRIPTION
Hey there! Not sure if you accept prs in this repo, because I see that you have another one [here](https://github.com/halop/OC_Toolkit_SC_EOS).

This PR related to sys-clk settings. Just fix issue with mistake in `reversenx_sync` option and add support to new version [sys-clc 1.2.0](https://discord.com/channels/854839758815363072/1173171845139288114/1383474985649176637) from `meha`. As you know it added an additional option for GPU_DVFS. This change will not break other versions of sys-clk so it should be fine. Let me know if it make sense, thanks!